### PR TITLE
New steps 3, 5, and a note how to find pyinstaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,17 +107,28 @@ PyInstaller can build/freeze/compile MC Extractor at all three supported platfor
 
 > pip3 install colorama
 
-3. Use pip to install PTable (Github, boxchar branch):
+3. Use pip to install setuptools:
+
+> pip3 install setuptools
+
+4. Use pip to install PTable (Github, boxchar branch):
 
 > pip3 install https://github.com/platomav/PTable/archive/boxchar.zip
 
-4. Use pip to install PyInstaller (PyPi):
+5. Use pip to install wheel:
+
+> pip3 install wheel
+
+6. Use pip to install PyInstaller (PyPi):
 
 > pip3 install pyinstaller
 
-5. Build/Freeze/Compile MC Extractor:
+7. Build/Freeze/Compile MC Extractor:
 
 > pyinstaller --noupx --onefile MCE.py
+
+If you are getting 'pyinstaller: command not found', find / -name "pyinstaller"
+to locate this executable. You may discover it at ~/.local/bin/pyinstaller
 
 At dist folder you should find the final MCE executable
 


### PR DESCRIPTION
about new "3." : If I don't run "pip3 install setuptools" before installing PTable,
I'm getting "  ModuleNotFoundError: No module named 'setuptools' " at "4."
about new "5." : If I don't run "pip3 install wheel" before installing PyInstaller,
I'm getting " error: invalid command 'bdist_wheel' at "6."