### PR TITLE
detect & allow other bsd based operating systems

### DIFF
--- a/MCE.py
+++ b/MCE.py
@@ -37,7 +37,7 @@ col_e = colorama.Fore.RESET + colorama.Style.RESET_ALL
 mce_os = sys.platform
 if mce_os == 'win32' :
 	cl_wipe = 'cls'
-elif mce_os.startswith('linux') or mce_os == 'darwin' :
+elif mce_os.startswith('linux') or mce_os == 'darwin' or mce_os.find('bsd') != -1  :
 	cl_wipe = 'clear'
 else :
 	print(col_r + '\nError: ' + col_e + 'Unsupported platform "%s"!\n' % mce_os)


### PR DESCRIPTION
MCExtractor works on other bsd based systems (in addition to macos), with no additional minimal requirements (python3.6 with sqlite3).

Tested on freebsd 12

![image](https://user-images.githubusercontent.com/35944068/50545816-74cd4680-0c14-11e9-9cac-d9eda5598d2f.png)

Signed-off-by: Rob Gill <rrobgill@protonmail.com>