### PR TITLE
Non-windows tweaks

### DIFF
--- a/MCE.py
+++ b/MCE.py
@@ -822,7 +822,10 @@ if param.mce_extr or param.ubu_test :
 	pass
 else :
 	sys.excepthook = show_exception_and_exit # Pause after any unexpected python exception
-	if mce_os == 'win32' : ctypes.windll.kernel32.SetConsoleTitleW(title) # Set console window title
+	# Set console window title
+	if mce_os == 'win32' : ctypes.windll.kernel32.SetConsoleTitleW(title)
+	if mce_os.startswith('linux') or mce_os == 'darwin' or mce_os.find('bsd') != -1 :
+		sys.stdout.write("\x1b]2;" + title + "\x07")
 
 if not param.skip_intro :
 	mce_hdr()

--- a/MCE.py
+++ b/MCE.py
@@ -593,9 +593,12 @@ def get_script_dir(follow_symlinks=True) :
 
 # https://stackoverflow.com/a/781074
 def show_exception_and_exit(exc_type, exc_value, tb) :
-	print(col_r + '\nError: MCE just crashed, please report the following:\n')
-	traceback.print_exception(exc_type, exc_value, tb)
-	if not param.skip_pause : input(col_e + '\nPress enter to exit')
+	if exc_type is KeyboardInterrupt :
+		print('\n')
+	else :
+		print(col_r + '\nError: MCE just crashed, please report the following:\n')
+		traceback.print_exception(exc_type, exc_value, tb)
+		if not param.skip_pause : input(col_e + '\nPress enter to exit')
 	colorama.deinit() # Stop Colorama
 	sys.exit(-1)
 	


### PR DESCRIPTION
The terminal title-bar text is updated (the same text as used under windows):

![image](https://user-images.githubusercontent.com/35944068/50570553-e37ee100-0d87-11e9-8e1c-685bf47be588.png)

Control-c is handled cleanly, rather than raising an exception and subsequent error message.

before:
![image](https://user-images.githubusercontent.com/35944068/50570561-1628d980-0d88-11e9-8d23-2dcc1bcdd40a.png)

after:
![image](https://user-images.githubusercontent.com/35944068/50570557-0dd09e80-0d88-11e9-88d7-d91e4585441d.png)
