### PR TITLE
Feature: Added support for AMD Family 19h

### DIFF
--- a/MCE.py
+++ b/MCE.py
@@ -1131,7 +1131,7 @@ if param.get_last :
 # Intel - HeaderRev 01, Year 1993-2022, Day 01-31, Month 01-12, CPUID xxxxxx00, LoaderRev 00-01, PlatformIDs 000000xx, DataSize xxxxxx00, TotalSize xxxxxx00, Reserved1
 pat_icpu = re.compile(br'\x01\x00{3}.{4}(([\x00-\x22]\x20)|([\x93-\x99]\x19))[\x01-\x31][\x01-\x12].{3}\x00.{4}[\x01\x00]\x00{3}.\x00{3}.{3}\x00.{3}\x00{13}', re.DOTALL)
 
-# AMD - Year 20xx, Month 01-13, LoaderID 00-04, DataSize 00|10|20, InitFlag 00-01, NorthBridgeVEN_ID 0000|1022, SouthBridgeVEN_ID 0000|1022, BiosApiREV_ID 00-01, Reserved 00|AA
+# AMD - Year 20xx, Month 01-13, LoaderID 00-05, DataSize 00|10|20, InitFlag 00-01, NorthBridgeVEN_ID 0000|1022, SouthBridgeVEN_ID 0000|1022, BiosApiREV_ID 00-01, Reserved 00|AA
 pat_acpu = re.compile(br'\x20[\x01-\x31][\x01-\x13].{4}[\x00-\x05]\x80[\x00\x20\x10][\x00\x01].{4}((\x00{2})|(\x22\x10)).{2}((\x00{2})|(\x22\x10)).{6}[\x00\x01](\x00{3}|\xAA{3})', re.DOTALL)
 
 # VIA - Signature RRAS, Year 2006-2022 (0x07D6-0x07E5), Day 01-31, Month 01-12, LoaderRev 01, Reserved, DataSize xxxxxx00, TotalSize xxxxxx00

--- a/MCE.py
+++ b/MCE.py
@@ -1132,7 +1132,7 @@ if param.get_last :
 pat_icpu = re.compile(br'\x01\x00{3}.{4}(([\x00-\x22]\x20)|([\x93-\x99]\x19))[\x01-\x31][\x01-\x12].{3}\x00.{4}[\x01\x00]\x00{3}.\x00{3}.{3}\x00.{3}\x00{13}', re.DOTALL)
 
 # AMD - Year 20xx, Month 01-13, LoaderID 00-04, DataSize 00|10|20, InitFlag 00-01, NorthBridgeVEN_ID 0000|1022, SouthBridgeVEN_ID 0000|1022, BiosApiREV_ID 00-01, Reserved 00|AA
-pat_acpu = re.compile(br'\x20[\x01-\x31][\x01-\x13].{4}[\x00-\x04]\x80[\x00\x20\x10][\x00\x01].{4}((\x00{2})|(\x22\x10)).{2}((\x00{2})|(\x22\x10)).{6}[\x00\x01](\x00{3}|\xAA{3})', re.DOTALL)
+pat_acpu = re.compile(br'\x20[\x01-\x31][\x01-\x13].{4}[\x00-\x05]\x80[\x00\x20\x10][\x00\x01].{4}((\x00{2})|(\x22\x10)).{2}((\x00{2})|(\x22\x10)).{6}[\x00\x01](\x00{3}|\xAA{3})', re.DOTALL)
 
 # VIA - Signature RRAS, Year 2006-2022 (0x07D6-0x07E5), Day 01-31, Month 01-12, LoaderRev 01, Reserved, DataSize xxxxxx00, TotalSize xxxxxx00
 pat_vcpu = re.compile(br'\x52\x52\x41\x53.{4}[\xD6-\xE6]\x07[\x01-\x1F][\x01-\x0C].{3}\x00.{4}\x01\x00{3}.{7}\x00.{3}\x00', re.DOTALL)
@@ -1531,8 +1531,9 @@ for in_file in source :
 		elif cpu_id[2:4] in ['68'] : mc_len = 0x980
 		elif cpu_id[2:4] in ['70','73'] : mc_len = 0xD60
 		elif cpu_id[2:4] in ['80','81','82','83','86','87'] : mc_len = 0xC80
+		elif cpu_id[2:4] in ['A0'] : mc_len = 0x15C0
 		else : mc_len = 0
-		
+
 		mc_data = reading[mc_bgn:mc_bgn + mc_len]
 		mc_file_chk = adler32(mc_data) # Custom Data-only Checksum
 		valid_chk = checksum32(mc_data[0x40:]) # AMD File Checksum (Data+Padding)

--- a/MCE.py
+++ b/MCE.py
@@ -1531,7 +1531,7 @@ for in_file in source :
 		elif cpu_id[2:4] in ['68'] : mc_len = 0x980
 		elif cpu_id[2:4] in ['70','73'] : mc_len = 0xD60
 		elif cpu_id[2:4] in ['80','81','82','83','86','87'] : mc_len = 0xC80
-		elif cpu_id[2:4] in ['A0', 'A2'] : mc_len = 0x15C0
+		elif cpu_id[2:4] in ['A0', 'A2', 'A5'] : mc_len = 0x15C0
 		else : mc_len = 0
 
 		mc_data = reading[mc_bgn:mc_bgn + mc_len]

--- a/MCE.py
+++ b/MCE.py
@@ -1531,7 +1531,7 @@ for in_file in source :
 		elif cpu_id[2:4] in ['68'] : mc_len = 0x980
 		elif cpu_id[2:4] in ['70','73'] : mc_len = 0xD60
 		elif cpu_id[2:4] in ['80','81','82','83','86','87'] : mc_len = 0xC80
-		elif cpu_id[2:4] in ['A0'] : mc_len = 0x15C0
+		elif cpu_id[2:4] in ['A0', 'A2'] : mc_len = 0x15C0
 		else : mc_len = 0
 
 		mc_data = reading[mc_bgn:mc_bgn + mc_len]


### PR DESCRIPTION
I've added support for AMD Family 19h processors (also know as Zen 3). Starting with Zen 3, the microcode is now 5,568 bytes in size.